### PR TITLE
background-color change for readability

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -80,6 +80,7 @@ em {font-style: italic;}
 
 body {
 	background: url('/images/new/diag-striped.png');
+	background-color: #202020;
 	color: #fff;
 
 	margin: 0 auto;


### PR DESCRIPTION
This sets the background-color of the page to the same color as the background image so that text is readable before the background image loads.
