### PR TITLE
Removes options related to name field

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -254,8 +254,6 @@ prose:
           help: 'By default, all forms include Email and ZIP/Post Code. Select additional fields to appear on the petition here.'
           label: 'Additional form fields'
           options:
-            - name: 'Name'
-              value: name
             - name: 'Street address'
               value: street_address
             - name: 'City'
@@ -268,8 +266,6 @@ prose:
           label: 'Required fields'
           help: 'If any of the additional fields selected above are meant to be required, choose them here.'
           options:
-            - name: 'Name'
-              value: name
             - name: 'Street address'
               value: street_address
             - name: 'City'

--- a/site/_layouts/action-network-petitions.html
+++ b/site/_layouts/action-network-petitions.html
@@ -58,10 +58,8 @@
     </figure>
 
     <form id="petition-form" class="petition-form" accept-charset="UTF-8" action="https://actionnetwork.org/petitions/{% if page.action_network_petition_slug != '' %}{{ page.action_network_petition_slug }}{% else %}{{ page.action_network_title | slugify }}{% endif %}/signatures" method="post" data-host="{{ site.petitions_api }}" data-petition-id="{{ site.petition_identifiers[page.action_network_title] | default: 'undefined' }}">
-      {% if page.additional_fields contains 'name' %}
-      <label class="visually-hidden" for="form-first_name">Name{% unless page.required_fields contains 'name' %} (optional){% endunless %}:</label>
-      <input type="text" id="form-first_name" class="name {{ fields_class }}" name="signature[first_name]" placeholder="Name{% unless page.required_fields contains 'name' %} (optional){% endunless %}" {% if page.required_fields contains 'name' %} required{% endif %}/>
-      {% endif %}
+      <label class="visually-hidden" for="form-first_name">Name (optional):</label>
+      <input type="text" id="form-first_name" class="name {{ fields_class }}" name="signature[first_name]" placeholder="Name (optional)" />
 
       <label class="visually-hidden" for="form-email">Email:</label>
       <input type="email" id="form-email" name="signature[email]" class="email {{ fields_class }}" placeholder="Email" required/>

--- a/site/_petitions/2016/comey-resign.md
+++ b/site/_petitions/2016/comey-resign.md
@@ -20,10 +20,6 @@ social_description: The Apple vs FBI case is just his latest disaster. James Com
 share_image: "/img/action-network/comey1.jpeg"
 share_image_dims: 1160 x 629
 published: true
-additional_fields:
-  - name
-required_fields:
-  - name
 ---
 ![comey1.jpeg]({{site.baseurl}}/img/action-network/comey1.jpeg)
 

--- a/site/_petitions/2016/davis-pepper-spray.md
+++ b/site/_petitions/2016/davis-pepper-spray.md
@@ -11,8 +11,6 @@ search_title: "Let's put a statue of the pepper-spraying cop on UC Davis campus.
 petition_title: "Tell Chancellor Katehi:"
 petition_copy: "Keep the memory of the pepper-spraying incident alive by erecting a statue of Officer Pike on campus."
 opt_in: false
-additional_fields:
-  - name
 action_text: Sign the petition
 target_country: US
 search_description: "UC Davis is trying to scrub references to a 2011 pepper-spraying incident from the Internet. Instead they should memorialize the event with a statue of the pepper-spraying cop on campus."

--- a/site/_petitions/2016/digital-security.md
+++ b/site/_petitions/2016/digital-security.md
@@ -4,17 +4,13 @@ layout: "action-network-petitions"
 design: "white-two-column"
 action_network_title: "Burr-Feinstein Bill Tries To Outlaw Encryption"
 action_network_petition_slug: "never-weaken-digital-security"
-tags: 
+tags:
   - encryption
 search_title: Tell Congress Save Digital Security
 headline: "Burr-Feinstein Bill Tries To Outlaw Encryption"
 petition_title: "The Senate Intelligence Committee is trying to outlaw life-saving security."
 petition_copy: "Sign now to tell Congress, “Encryption keeps us safe. Vote no on ANY bill that would weaken security or require government backdoors.”"
 opt_in: true
-additional_fields: 
-  - name
-required_fields: 
-  - "null"
 action_text: "Sign now!"
 target_country: US
 search_description: null

--- a/site/_petitions/demo/blue-one-column.md
+++ b/site/_petitions/demo/blue-one-column.md
@@ -12,10 +12,7 @@ petition_copy: "Fridays should be free pizza day. Push legislation today to brin
 opt_in: false
 allow_comments: false
 additional_fields:
-  - name
   - street_address
-required_fields:
-  - name
 target_country: US
 search_description: null
 default_donation_frequency: "just-once"

--- a/site/_petitions/demo/blue-two-column.md
+++ b/site/_petitions/demo/blue-two-column.md
@@ -12,10 +12,7 @@ petition_copy: "Fridays should be free pizza day. Push legislation today to brin
 opt_in: false
 allow_comments: false
 additional_fields:
-  - name
   - street_address
-required_fields:
-  - name
 target_country: US
 search_description: null
 default_donation_frequency: "just-once"

--- a/site/_petitions/demo/white-two-column.md
+++ b/site/_petitions/demo/white-two-column.md
@@ -12,10 +12,7 @@ petition_copy: "Fridays should be free pizza day. Push legislation today to brin
 opt_in: false
 allow_comments: false
 additional_fields:
-  - name
   - street_address
-required_fields:
-  - name
 target_country: US
 search_description: null
 default_donation_frequency: "just-once"


### PR DESCRIPTION
Now including the name field isn't an option for campaigners, and is never required for people signing petitions.
Fixes https://trello.com/c/Dd2XknhF