### PR TITLE
og:image rewrite

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,7 +227,7 @@ module.exports = function (grunt) {
           rewriter: function (url) {
             var
               stamp = Date.now();
-            if (url[0] === '/' || (new RegExp('^<%=site.url %>')).test(url)) {
+            if (url[0] === '/' || /^<%=site.url %>/.test(url)) {
               return 'https://' + env.get('aws_s3_bucket') + url + '?' + stamp;
             } else {
               return url;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,7 +227,7 @@ module.exports = function (grunt) {
           rewriter: function (url) {
             var
               stamp = Date.now();
-            if (url[0] === '/' || /^<%=site.url %>/.test(url)) {
+            if (url[0] === '/') {
               return 'https://' + env.get('aws_s3_bucket') + url + '?' + stamp;
             } else {
               return url;

--- a/app.json
+++ b/app.json
@@ -9,15 +9,13 @@
   "env": {
     "TUMBLR_API_KEY": {
       "description": "API key for generating news posts",
-      "value": "secret"
+      "required": true
     },
     "AWS_ACCESS_KEY": {
-      "description": "",
-      "value": "secret"
+      "required": true
     },
     "AWS_SECRET_KEY": {
-      "description": "",
-      "value": "secret"
+      "required": true
     },
     "AWS_S3_BUCKET": {
       "description": "Where the images we snag from tumblr go",
@@ -44,8 +42,8 @@
       "value": "https://actionnetwork.org"
     },
     "ACTIONNETWORK_APIKEY": {
-      "description": "fftf API key for Action Network",
-      "value": "f944d034faa1131435eef72ca0bfcdf2"
+      "description": "API key for Action Network",
+      "required": true
     }
   },
   "addons": [

--- a/site/_includes/meta.html
+++ b/site/_includes/meta.html
@@ -1,9 +1,4 @@
-{% if page.share_image contains 'http' %}
-  {% assign share_img = page.share_image | uri_escape %}
-{% else %}
-  {% assign share_img = site.url | append: page.share_image | uri_escape %}
-{% endif %}
-
+{% assign share_img = page.share_image | uri_escape %}
 {% assign dims = page.share_image_dims | split: " × " %}
 
 <meta charset="utf-8">


### PR DESCRIPTION
Don't prepend `site.url` for site-root relative share image, allow `cdnify` to rewrite it instead.